### PR TITLE
chore: adds reset-test-db fn

### DIFF
--- a/env/dev/clj/user.clj
+++ b/env/dev/clj/user.clj
@@ -26,3 +26,9 @@
 
 (defn create-migration [name]
   (migrations/create name (select-keys env [:database-url])))
+
+;; TODO: figure out how to call this function from test env
+(defn reset-test-db []
+  (migrations/migrate
+    ["reset"]
+    {:database-url "jdbc:postgresql://localhost/pb_test?user=postgres&password=postgres"}))


### PR DESCRIPTION
usage:

`rlwrap lein repl`

once in repl you can run:

`(restart)`

and the

`(reset-test-db)`